### PR TITLE
Cambio en el efecto añadido obsidian dagger

### DIFF
--- a/src/main/java/net/rudahee/metallics_arts/modules/powers/PowersEventHandler.java
+++ b/src/main/java/net/rudahee/metallics_arts/modules/powers/PowersEventHandler.java
@@ -246,7 +246,7 @@ public class PowersEventHandler {
 
                         if (itemInHand.getItem() == ModItems.OBSIDIAN_DAGGER.get()) {
                             if (Math.random() < 0.30d) {
-                                event.getEntity().addEffect(new MobEffectInstance(MobEffects.WITHER, 20, 1, true, true, false));
+                                event.getEntity().addEffect(new MobEffectInstance(MobEffects.WITHER, 41, 1, true, true, false));
                             }
                         }
 


### PR DESCRIPTION
Añadidos ticks para el efecto whiter causando verdadero daño al jugador y no solo dando el efecto. Se dan 41 ticks debido a que el efecto whiter causa daño cada 40 , asegurando así el obtener daño.